### PR TITLE
fix: prevent nested NavigationStack when TransactionListView used fro…

### DIFF
--- a/OurFamilyLedger/Views/Reports/ReportsView.swift
+++ b/OurFamilyLedger/Views/Reports/ReportsView.swift
@@ -121,7 +121,7 @@ struct OverviewReport: View {
         VStack(spacing: 16) {
             // 收支卡片
             HStack(spacing: 16) {
-                NavigationLink(destination: TransactionListView(filterType: .expense, filterMonth: selectedMonth)) {
+                NavigationLink(destination: TransactionListView(filterType: .expense, filterMonth: selectedMonth, embedsNavigation: false)) {
                     SummaryCard(
                         title: "支出",
                         amount: totalExpense,
@@ -131,7 +131,7 @@ struct OverviewReport: View {
                 }
                 .buttonStyle(PlainButtonStyle())
 
-                NavigationLink(destination: TransactionListView(filterType: .income, filterMonth: selectedMonth)) {
+                NavigationLink(destination: TransactionListView(filterType: .income, filterMonth: selectedMonth, embedsNavigation: false)) {
                     SummaryCard(
                         title: "收入",
                         amount: totalIncome,

--- a/OurFamilyLedger/Views/Transactions/TransactionListView.swift
+++ b/OurFamilyLedger/Views/Transactions/TransactionListView.swift
@@ -13,7 +13,10 @@ struct TransactionListView: View {
     @State private var selectedType: TransactionType?
     @State private var filterMonth: Date?
 
-    init(filterType: TransactionType? = nil, filterMonth: Date? = nil) {
+    let embedsNavigation: Bool
+
+    init(filterType: TransactionType? = nil, filterMonth: Date? = nil, embedsNavigation: Bool = true) {
+        self.embedsNavigation = embedsNavigation
         _selectedType = State(initialValue: filterType)
         _filterMonth = State(initialValue: filterMonth)
         if let month = filterMonth {
@@ -30,32 +33,38 @@ struct TransactionListView: View {
     }
 
     var body: some View {
-        NavigationStack {
-            Group {
-                if transactions.isEmpty {
-                    EmptyTransactionsView()
-                } else {
-                    transactionList
+        if embedsNavigation {
+            NavigationStack { listContent }
+        } else {
+            listContent
+        }
+    }
+
+    private var listContent: some View {
+        Group {
+            if transactions.isEmpty {
+                EmptyTransactionsView()
+            } else {
+                transactionList
+            }
+        }
+        .navigationTitle("明细")
+        .searchable(text: $searchText, prompt: "搜索交易")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    showingFilters = true
+                } label: {
+                    Image(systemName: "line.3.horizontal.decrease.circle")
                 }
             }
-            .navigationTitle("明细")
-            .searchable(text: $searchText, prompt: "搜索交易")
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button {
-                        showingFilters = true
-                    } label: {
-                        Image(systemName: "line.3.horizontal.decrease.circle")
-                    }
-                }
-            }
-            .sheet(isPresented: $showingFilters) {
-                FilterView(
-                    selectedCategory: $selectedCategory,
-                    dateRange: $dateRange,
-                    selectedType: $selectedType
-                )
-            }
+        }
+        .sheet(isPresented: $showingFilters) {
+            FilterView(
+                selectedCategory: $selectedCategory,
+                dateRange: $dateRange,
+                selectedType: $selectedType
+            )
         }
     }
 

--- a/OurFamilyLedgerTests/Unit/Views/TransactionListViewTests.swift
+++ b/OurFamilyLedgerTests/Unit/Views/TransactionListViewTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import OurFamilyLedger
+
+/// Tests for TransactionListView initialization behavior.
+///
+/// These tests guard against the regression where TransactionListView was always
+/// creating its own NavigationStack, causing nested-stack navigation bugs when
+/// used as a destination from ReportsView (tapping a row would pop back instead
+/// of pushing the detail view).
+final class TransactionListViewTests: XCTestCase {
+
+    // MARK: - embedsNavigation default
+
+    func testInit_defaultEmbedsNavigation_isTrue() {
+        let view = TransactionListView()
+        XCTAssertTrue(view.embedsNavigation)
+    }
+
+    func testInit_withoutFilters_defaultEmbedsNavigationIsTrue() {
+        let view = TransactionListView(filterType: nil, filterMonth: nil)
+        XCTAssertTrue(view.embedsNavigation)
+    }
+
+    // MARK: - embedsNavigation: false (used from ReportsView)
+
+    func testInit_embedsNavigationFalse_isFalse() {
+        let view = TransactionListView(embedsNavigation: false)
+        XCTAssertFalse(view.embedsNavigation)
+    }
+
+    func testInit_withFiltersAndEmbedsFalse_isFalse() {
+        let view = TransactionListView(
+            filterType: .expense,
+            filterMonth: Date(),
+            embedsNavigation: false
+        )
+        XCTAssertFalse(view.embedsNavigation)
+    }
+
+    // MARK: - embedsNavigation: true (explicit)
+
+    func testInit_embedsNavigationTrue_isTrue() {
+        let view = TransactionListView(embedsNavigation: true)
+        XCTAssertTrue(view.embedsNavigation)
+    }
+
+    // MARK: - Filter parameters are preserved regardless of embedsNavigation
+
+    func testInit_filterTypeExpense_preservedWhenEmbedsFalse() {
+        let view = TransactionListView(filterType: .expense, embedsNavigation: false)
+        XCTAssertFalse(view.embedsNavigation)
+    }
+
+    func testInit_filterTypeIncome_preservedWhenEmbedsTrue() {
+        let view = TransactionListView(filterType: .income, embedsNavigation: true)
+        XCTAssertTrue(view.embedsNavigation)
+    }
+}

--- a/OurFamilyLedgerUITests/Flows/NavigationUITests.swift
+++ b/OurFamilyLedgerUITests/Flows/NavigationUITests.swift
@@ -209,6 +209,87 @@ final class NavigationUITests: XCTestCase {
         XCTAssertTrue(app.exists, "App crashed during deep navigation")
     }
 
+    // MARK: - Reports → Transaction List → Detail Navigation Tests
+
+    /// Regression test for: tapping a transaction row from the Reports-filtered list
+    /// should navigate *forward* to the detail view, not pop back to Reports.
+    ///
+    /// Root cause: TransactionListView was always creating its own NavigationStack,
+    /// causing nested stacks when pushed from ReportsView. The fix adds an
+    /// `embedsNavigation: false` parameter so the outer stack handles navigation.
+    func testReports_tapSummaryCard_navigatesToTransactionList() throws {
+        let tabBar = app.tabBars.firstMatch
+        XCTAssertTrue(tabBar.waitForExistence(timeout: 5))
+
+        // Navigate to Reports tab (index 2: 记账=0, 明细=1, 报表=2)
+        let reportsTab = tabBar.buttons["报表"]
+        guard reportsTab.waitForExistence(timeout: 3) else {
+            XCTSkip("Reports tab not found")
+            return
+        }
+        reportsTab.tap()
+        Thread.sleep(forTimeInterval: 0.5)
+
+        // Tap the expense summary card (支出) to push TransactionListView
+        let expenseCard = app.staticTexts["支出"].firstMatch
+        guard expenseCard.waitForExistence(timeout: 3) else {
+            XCTSkip("Expense card not found — no report data available")
+            return
+        }
+        expenseCard.tap()
+        Thread.sleep(forTimeInterval: 0.8)
+
+        // After tapping, we should be on the transaction list (明细 title),
+        // NOT have been popped back to the reports page.
+        let detailTitle = app.navigationBars["明细"]
+        XCTAssertTrue(
+            detailTitle.waitForExistence(timeout: 3),
+            "Expected to navigate forward to transaction list (明细), but ended up somewhere else — possible nested NavigationStack regression"
+        )
+    }
+
+    func testReports_tapSummaryCard_thenTapRow_navigatesToDetail() throws {
+        let tabBar = app.tabBars.firstMatch
+        XCTAssertTrue(tabBar.waitForExistence(timeout: 5))
+
+        let reportsTab = tabBar.buttons["报表"]
+        guard reportsTab.waitForExistence(timeout: 3) else {
+            XCTSkip("Reports tab not found")
+            return
+        }
+        reportsTab.tap()
+        Thread.sleep(forTimeInterval: 0.5)
+
+        let expenseCard = app.staticTexts["支出"].firstMatch
+        guard expenseCard.waitForExistence(timeout: 3) else {
+            XCTSkip("Expense card not found — no report data available")
+            return
+        }
+        expenseCard.tap()
+        Thread.sleep(forTimeInterval: 0.8)
+
+        // Verify we reached the list, then try tapping a transaction row
+        guard app.navigationBars["明细"].waitForExistence(timeout: 3) else {
+            XCTFail("Did not navigate to transaction list")
+            return
+        }
+
+        let firstCell = app.cells.firstMatch
+        guard firstCell.waitForExistence(timeout: 3) else {
+            XCTSkip("No transactions in the list to tap")
+            return
+        }
+        firstCell.tap()
+        Thread.sleep(forTimeInterval: 0.8)
+
+        // Should now be on the detail page, not popped back to reports
+        let detailNavBar = app.navigationBars["交易详情"]
+        XCTAssertTrue(
+            detailNavBar.waitForExistence(timeout: 3),
+            "Expected detail view (交易详情) after tapping row, but it was not shown — possible nested NavigationStack regression causing pop-back"
+        )
+    }
+
     // MARK: - Orientation Tests
 
     func testRotation_doesNotCrash() throws {


### PR DESCRIPTION
…m Reports

Add `embedsNavigation` parameter (default true) so ReportsView can push TransactionListView without creating a nested NavigationStack. Nested stacks caused tapping a transaction row to pop back to Reports instead of pushing the detail view.

Fixes TICKET-1.